### PR TITLE
domd_cfg: add image loading callbacks for DomD config

### DIFF
--- a/src/domd_cfg.c
+++ b/src/domd_cfg.c
@@ -379,6 +379,23 @@ extern char __img_domd_end[];
 extern char __dtb_domd_start[];
 extern char __dtb_domd_end[];
 
+static int load_domd_image_bytes(uint8_t *buf, size_t bufsize,
+		   uint64_t offset, void *image_info)
+{
+	ARG_UNUSED(image_info);
+
+	memcpy(buf, __img_domd_start + offset, bufsize);
+	return 0;
+}
+
+static ssize_t get_domd_image_size(void *image_info, uint64_t *size)
+{
+	ARG_UNUSED(image_info);
+
+	*size = __img_domd_end - __img_domd_start;
+	return 0;
+}
+
 struct xen_domain_cfg domd_cfg = {
 	.mem_kb = 16384,
 
@@ -400,8 +417,8 @@ struct xen_domain_cfg domd_cfg = {
 	.dtdevs = domd_dtdevs,
 	.nr_dtdevs = 0,
 
-	.img_start = __img_domd_start,
-	.img_end = __img_domd_end,
+	.load_image_bytes = load_domd_image_bytes,
+	.get_image_size = get_domd_image_size,
 
 	.dtb_start = __dtb_domd_start,
 	.dtb_end = __dtb_domd_end,


### PR DESCRIPTION
zephyr-xenlib changes interface for image loading - now they should be loaded by function, that are selected in domain config as callbacks. Also img_start/img_end struct member was dropped from generic domain config structure. It is needed to be able to load domain images from persistent storage too (instead of legacy way with binary sections).

This commit adds temporary solution for running zephyr-dom0-xt, which uses domd image from dedicated section. So, it was needed to add custom callback, which will load image to assigned buffer and return image size to zephyr-xenlib during domain creation.

All of these changes will be dropped after migration to persistent storage.