### PR TITLE
Allow all modules from west.yaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(ZEPHYR_MODULES ../zephyr-xenlib)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)


### PR DESCRIPTION
This patch removes limitation to use only xenlib module