### PR TITLE
zephyr-dom0-xt: rpi5; remove usage of xen_dom0 snippet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,7 +197,7 @@ For example, to build it for **rpi_5** board with one Xen guest domain configura
 
 .. code-block:: bash
 
-    west build -b rpi_5 -p always -S xen_dom0 zephyr-dom0-xt -- \
+    west build -b rpi_5 -p always zephyr-dom0-xt -- \
     -DCONFIG_USE_DEFAULT_DOM_CFG=n -DCONFIG_DOM_CFG_BOARD_EXT=\"domd\"
 
 For example, to build it for **rpi_5** board with two Xen guest domain configurations
@@ -205,7 +205,7 @@ For example, to build it for **rpi_5** board with two Xen guest domain configura
 
 .. code-block:: bash
 
-    west build -b rpi_5 -p always -S xen_dom0 zephyr-dom0-xt -- \
+    west build -b rpi_5 -p always zephyr-dom0-xt -- \
     -DCONFIG_USE_DEFAULT_DOM_CFG=n
 
 Running
@@ -253,14 +253,14 @@ Once build is finished copy ``zephyr.bin`` into the
 
     For RPI5 It's default configuration, so this step can be skipped.
 
-Build zephyr-dom0-xt
+RPI5 Build zephyr-dom0-xt
 ====================
 
 Run below command to build **zephyr-dom0-xt**:
 
 .. code-block:: bash
 
-    west build -b rpi_5 -p always -S xen_dom0 zephyr-dom0-xt
+    west build -b rpi_5 -p always zephyr-dom0-xt
 
 Once build is finished copy ``zephyr.bin`` into RPI5 ``bootfs``, so it can be picked up by
 booting process.

--- a/boards/rpi_5.conf
+++ b/boards/rpi_5.conf
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 EPAM Systems
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_XEN_DOM0=y
+
 CONFIG_XSTAT=y
 CONFIG_XSTAT_SHELL_CMDS=y
 

--- a/boards/rpi_5.overlay
+++ b/boards/rpi_5.overlay
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 EPAM Systems.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /delete-node/ &sram0;
+
+#include <mem.h>
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <1>;
+
+	chosen {
+		zephyr,console = &xen_consoleio_hvc;
+		zephyr,shell-uart = &xen_consoleio_hvc;
+	};
+
+	psci {
+		method = "hvc";
+	};
+
+	xen_consoleio_hvc: hvc {
+		compatible = "xen,hvc-consoleio";
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000002800000-0x00000002840000
+	 * Also, add extended region 1:
+	 * (XEN) d0: extended region 1: 0x40000000->0x5fe00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@2000000 {
+		compatible = "xen,xen";
+		reg = <0x00 0x2000000 0x40000>, <0x00 0x2200000 0x5400000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings totalling 512MB for dom0:
+	 * (XEN) BANK[0] 0x00000060000000-0x00000080000000 (512MB)
+	 * (XEN) Loading zImage from 0000000000080000 to 0000000060000000-0000000060038004
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	sram0: memory@10000000 {
+		compatible = "mmio-sram";
+		reg = <0x00 0x10000000 DT_SIZE_M(128)>;
+	};
+};
+
+&uart10 {
+	status = "disabled";
+};


### PR DESCRIPTION
The usage of xen_dom0 with Zephyr applications is proved to be
problematic [1]. And moving only "hypervisor" and "memory" nodes in
zephyr-dom0-xt rpi_5.overlay doesn't solve all problems as it cuses build
warning due to different usage of #address-cells/size-cells in RPI5 DTS.

Actulaly if "hypervisor" and "memory" are moved in application board
files the xen_dom0 snippet will be left to provide just proper Xen
HVC console and to enable CONFIG_XEN_DOM0.

Hence, drop usage of xen_dom0 snippet for zephyr-dom0-xt application and
move all needed parts in application board files. Now everything is one
place.

[1] https://github.com/xen-troops/zephyr-xenlib/pulls