### PR TITLE
west: Add xrun project to the build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,3 +17,6 @@ manifest:
     - name: zephyr-xenlib
       remote: xentroops
       revision: main
+    - name: zephyr-xrun
+      remote: xentroops
+      revision: main


### PR DESCRIPTION
As the xrun is now a separate project, it should be added to the build separately.