### PR TITLE
zephyr-dom0-xt: fix default build without builtin domu1

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -88,11 +88,17 @@ config DOM_CFG_DOMU0_DTB_BIN_FILE
 	string "Location for Domain-U0 device-tree"
 	default "domu0.dtb"
 
+config DOM_CFG_DOMU1_ENABLE
+	bool "Enable builtin Domain-U1 kernel binary"
+	default n
+
 config DOM_CFG_DOMU1_IMAGE_BIN_FILE
 	string "Location for Domain-U1 kernel binary"
+	depends on DOM_CFG_DOMU1_ENABLE
 
 config DOM_CFG_DOMU1_DTB_BIN_FILE
 	string "Location for Domain-U1 device-tree"
+	depends on DOM_CFG_DOMU1_ENABLE
 
 endif #DOM_CFG_BUILTIN_IMAGES
 


### PR DESCRIPTION
The default build is failed now because string Kconfig options
  CONFIG_DOM_CFG_DOMU1_IMAGE_BIN_FILE
  CONFIG_DOM_CFG_DOMU1_DTB_BIN_FILE
are defined as empty strings always which isn't handled properly with pre-processor and causes defined(CONFIG_DOM_CFG_DOMU1_DTB_BIN_FILE) to return true.

Fix it by adding additional Kconfig option:
 CONFIG_DOM_CFG_DOMU1_ENABLE
and make DomU1 Kconfig option depend on it. This will guarantee that DomU1 Kconfig options are not defined, so defined() directive will work as expected and build system will not try to include non-existed DomU1 images.

This will allow to build for qemu or rcar platform.