### PR TITLE
west.yaml: stabilize FATFS revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,4 +21,4 @@ manifest:
       revision: main
     - name: fatfs
       remote: zephyrproject-rtos
-      revision: master
+      revision: 427159bf95ea49b7680facffaa29ad506b42709b


### PR DESCRIPTION
Set stable revision for the FATFS library. This prevents potential issues of unexpected fatfs update as an external component.