### PR TITLE
boards: Add board overlays

### DIFF
--- a/boards/qemu_cortex_a53.overlay
+++ b/boards/qemu_cortex_a53.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Renesas Electronics Corporation.
+ * Copyright (C) 2023 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/delete-node/ &sram0;
+
+&uart0 {
+	/* Xen consoleio will be used */
+	status = "disabled";
+};
+
+/ {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000040200000-0x00000040240000
+	 * Also, add extended region 1:
+	 * (XEN) Extended region 1: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@40200000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x40200000 0x0 0x40000 0x0 0x40400000 0x0 0x17C00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000058000000-0x00000060000000 (128MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	soc {
+		sram0: memory@58000000 {
+			device_type = "mmio-sram";
+			reg = <0x00 0x58000000 0x00 DT_SIZE_M(128)>;
+		};
+	};
+};

--- a/boards/rcar_h3ulcb_ca57.overlay
+++ b/boards/rcar_h3ulcb_ca57.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Renesas Electronics Corporation.
+ * Copyright (C) 2023 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/delete-node/ &ram;
+
+/ {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
+	 * Also, add extended region 2:
+	 * (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@88080000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	ram: memory@60000000 {
+		device_type = "mmio-sram";
+		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
+	};
+};

--- a/boards/rcar_salvator_xs_m3.overlay
+++ b/boards/rcar_salvator_xs_m3.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Renesas Electronics Corporation.
+ * Copyright (C) 2023 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/delete-node/ &ram;
+
+/ {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
+	 * Also, add extended region 2:
+	 * (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@88080000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	ram: memory@60000000 {
+		device_type = "mmio-sram";
+		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
+	};
+};

--- a/boards/rcar_spider_ca55.overlay
+++ b/boards/rcar_spider_ca55.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Renesas Electronics Corporation.
+ * Copyright (C) 2023 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/delete-node/ &ram;
+
+/ {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000078080000-0x000000780c0000
+	 * Also, add extended region 1:
+	 * (XEN) Extended region 1: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+
+	hypervisor: hypervisor@78080000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x78080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000080000000-0x00000090000000 (256MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	ram: memory@80000000 {
+		device_type = "mmio-sram";
+		reg = <0x00 0x80000000 0x00 DT_SIZE_M(256)>;
+	};
+};


### PR DESCRIPTION
Add board overlays that are required to run Dom0 Zephyr. These overlays were removed from xen_dom0 snippet, which broke the build. Place them here to fix it.