### PR TITLE
zephyr-dom0-xt: add code coverage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/prebuilt)
 
 target_sources(app PRIVATE src/dom0.c src/domain_bins.S)
 target_sources_ifdef(CONFIG_DOM_STORAGE_FATFS_ENABLE app PRIVATE src/storage.c)
+target_sources_ifdef(CONFIG_DOM_COVERAGE_ENABLE app PRIVATE src/cmd_gcov.c)
 
 if(CONFIG_USE_DEFAULT_DOM_CFG)
   target_sources(app PRIVATE src/domu_cfg.c)

--- a/Kconfig
+++ b/Kconfig
@@ -102,4 +102,13 @@ config DOM_CFG_DOMU1_DTB_BIN_FILE
 
 endif #DOM_CFG_BUILTIN_IMAGES
 
+config DOM_COVERAGE_ENABLE
+	bool "Enable code coverage with GCOV"
+	depends on SHELL
+	select FORCE_COVERAGE
+	select COVERAGE
+	help
+	  Enable code coverage with GCOV and enable shell command to print GCOV
+	  dump "gcov dump" in console.
+
 source "Kconfig.zephyr"

--- a/src/cmd_gcov.c
+++ b/src/cmd_gcov.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/debug/gcov.h>
+
+static int gcov_dump(const struct shell *shell, size_t argc, char **argv)
+{
+	gcov_coverage_dump();
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	subcmd_gcov,
+	SHELL_CMD_ARG(dump, NULL,
+			"Print gcov dump\n",
+			gcov_dump, 0, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(gcov, &subcmd_gcov, "GCOV commands", NULL, 0, 0);


### PR DESCRIPTION
This patch adds code coverage support which can be enabled by CONFIG_DOM_COVERAGE_ENABLE Kconfig option.

It also adds shell command "gcov dump" to print gcov report to console.