### PR TITLE
Backport to rpi5-v0.1: west.yaml: stabilize FATFS revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,4 +21,4 @@ manifest:
       revision: 72dbdad3d141bd8fed2688597453a516b70157f6
     - name: fatfs
       remote: zephyrproject-rtos
-      revision: master
+      revision: 427159bf95ea49b7680facffaa29ad506b42709b


### PR DESCRIPTION
Set stable revision for the FATFS library. This prevents potential issues of unexpected fatfs update as an external component.


Acked-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
Reviewed-by: Grygorii Strashko <grygorii_strashko@epam.com>
Acked-by: Dmytro Firsov <dmytro_firsov@epam.com>