### PR TITLE
Rpi5: dom0 add xrun lib and fix build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -22,3 +22,6 @@ manifest:
     - name: fatfs
       remote: zephyrproject-rtos
       revision: 427159bf95ea49b7680facffaa29ad506b42709b
+    - name: zephyr-xrun
+      remote: xentroops
+      revision: main


### PR DESCRIPTION
As the xrun is now a separate project, it should be added to the build separately.

PRs
Requires:
https://github.com/xen-troops/zephyr-xenlib/pull/91
https://github.com/xen-troops/zephyr-xrun/pull/1

were merged and broke zephyr-dom0-xt main build.