### PR TITLE
boards/rpi_5: add rpi_5_scmi.overlay

### DIFF
--- a/boards/rpi_5_scmi.overlay
+++ b/boards/rpi_5_scmi.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2024 EPAM Systems.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /delete-node/ &sram0;
+
+#include <mem.h>
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <1>;
+
+	sram0: memory@30000000 {
+		compatible = "mmio-sram";
+		reg = <0x00 0x30000000 DT_SIZE_M(128)>;
+	};
+};


### PR DESCRIPTION
Add rpi_5_scmi.overlay which allows to build and run zephyr-dom0-xt application when ARM SCMI is enabled.
The RAM layout is changed when ARM SCMI is enabled and Xen loads zephyr-dom0-xt app at different address 0x30000000, so rpi_5_scmi.overlay allows to cover this case. Also, in the future, it can be extended with DT SCMI nodes.

The EXTRA_DTC_OVERLAY_FILE can be used to apply rpi_5_scmi.overlay.

Build:
 west build -b rpi_5 -p always zephyr-dom0-xt -- \
 -DEXTRA_DTC_OVERLAY_FILE=boards/rpi_5_scmi.overlay

The EXTRA_DTC_OVERLAY_FILE can be added in rpi5.yaml.